### PR TITLE
Remove CoinRun episode resets from dataset

### DIFF
--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -1,9 +1,10 @@
 """
 Generates a dataset of random-action CoinRun episodes.
-WARNING: Default (10,000 episode) dataset is very large at >100GB.
+Episodes are saved individually as memory-mapped files for efficient loading.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from gym3 import types_np
 import numpy as np
@@ -14,21 +15,41 @@ import tyro
 @dataclass
 class Args:
     num_episodes: int = 10000
+    output_dir: str = "data/coinrun_episodes"
+    min_episode_length: int = 50
 
 
 args = tyro.cli(Args)
-data = []
-for i in range(args.num_episodes):
+output_dir = Path(args.output_dir)
+output_dir.mkdir(parents=True, exist_ok=True)
+
+# --- Generate episodes ---
+i = 0
+metadata = []
+while i < args.num_episodes:
     seed = np.random.randint(0, 10000)
     env = ProcgenGym3Env(num=1, env_name="coinrun", start_level=seed)
-    step = 0
     dataseq = []
+
+    # --- Run episode ---
     for j in range(1000):
         env.act(types_np.sample(env.ac_space, bshape=(env.num,)))
         rew, obs, first = env.observe()
-        step += 1
         dataseq.append(obs["rgb"])
-    dataseq = np.concatenate(dataseq, axis=0)
-    data.append(dataseq)
-data_to_file = np.array(data)
-np.save("data/coinrun.npy", data_to_file)
+        if first:
+            break
+
+    # --- Save episode ---
+    if len(dataseq) >= args.min_episode_length:
+        episode_data = np.concatenate(dataseq, axis=0)
+        episode_path = output_dir / f"episode_{i}.npy"
+        np.save(episode_path, episode_data.astype(np.uint8))
+        metadata.append({"path": str(episode_path), "length": len(dataseq)})
+        print(f"Episode {i} completed, length: {len(dataseq)}")
+        i += 1
+    else:
+        print(f"Episode too short ({len(dataseq)}), resampling...")
+
+# --- Save metadata ---
+np.save(output_dir / "metadata.npy", metadata)
+print(f"Dataset generated with {len(metadata)} valid episodes")

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -7,6 +7,7 @@ from flax.training import orbax_utils
 from flax.training.train_state import TrainState
 import optax
 import orbax
+from orbax.checkpoint import PyTreeCheckpointer
 import numpy as np
 import dm_pix as pix
 import jax
@@ -28,7 +29,8 @@ class Args:
     seq_len: int = 16
     image_channels: int = 3
     image_resolution: int = 64
-    file_path: str = "data/coinrun.npy"
+    data_dir: str = "data/coinrun_episodes"
+    checkpoint: str = ""
     # Optimization
     vq_beta: float = 0.25
     batch_size: int = 48
@@ -56,33 +58,6 @@ class Args:
 
 
 args = tyro.cli(Args)
-rng = jax.random.PRNGKey(args.seed)
-if args.log:
-    wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
-
-# --- Construct train state ---
-tokenizer = TokenizerVQVAE(
-    in_dim=args.image_channels,
-    model_dim=args.model_dim,
-    latent_dim=args.latent_dim,
-    num_latents=args.num_latents,
-    patch_size=args.patch_size,
-    num_blocks=args.num_blocks,
-    num_heads=args.num_heads,
-    dropout=args.dropout,
-    codebook_dropout=args.codebook_dropout,
-)
-image_shape = (args.image_resolution, args.image_resolution, args.image_channels)
-inputs = dict(
-    videos=jnp.zeros((args.batch_size, args.seq_len, *image_shape), dtype=jnp.float32),
-)
-rng, _rng = jax.random.split(rng)
-init_params = tokenizer.init(_rng, inputs)
-lr_schedule = optax.warmup_cosine_decay_schedule(
-    args.min_lr, args.max_lr, args.warmup_steps, args.num_steps
-)
-tx = optax.adamw(learning_rate=lr_schedule, b1=0.9, b2=0.9, weight_decay=1e-4)
-train_state = TrainState.create(apply_fn=tokenizer.apply, params=init_params, tx=tx)
 
 
 def tokenizer_loss_fn(params, state, inputs):
@@ -118,7 +93,6 @@ def tokenizer_loss_fn(params, state, inputs):
     return loss, (outputs["recon"], metrics)
 
 
-# --- Define train step ---
 @jax.jit
 def train_step(state, inputs):
     grad_fn = jax.value_and_grad(tokenizer_loss_fn, has_aux=True, allow_int=True)
@@ -137,48 +111,88 @@ def train_step(state, inputs):
     return state, loss, recon, metrics
 
 
-# --- TRAIN LOOP ---
-dataloader = get_dataloader(args.file_path, args.seq_len, args.batch_size)
-step = 0
-while step < args.num_steps:
-    for videos in dataloader:
-        # --- Train step ---
-        rng, _rng = jax.random.split(rng)
-        inputs = dict(
-            videos=jnp.array(videos, dtype=jnp.float32) / 255.0,
-            rng=_rng,
-        )
-        train_state, loss, recon, metrics = train_step(train_state, inputs)
-        print(f"Step {step}, loss: {loss}")
-        step += 1
+if __name__ == "__main__":
+    rng = jax.random.PRNGKey(args.seed)
+    if args.log:
+        wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
 
-        # --- Logging ---
-        if args.log:
-            if step % args.log_interval == 0:
-                wandb.log({"loss": loss, "step": step, **metrics})
-            if step % args.log_image_interval == 0:
-                gt_seq = inputs["videos"][0]
-                recon_seq = recon[0].clip(0, 1)
-                comparison_seq = jnp.concatenate((gt_seq, recon_seq), axis=1)
-                comparison_seq = einops.rearrange(
-                    comparison_seq * 255, "t h w c -> h (t w) c"
-                )
-                log_images = dict(
-                    image=wandb.Image(np.asarray(gt_seq[0])),
-                    recon=wandb.Image(np.asarray(recon_seq[0])),
-                    true_vs_recon=wandb.Image(
-                        np.asarray(comparison_seq.astype(np.uint8))
-                    ),
-                )
-                wandb.log(log_images)
-            if step % args.log_checkpoint_interval == 0:
-                ckpt = {"model": train_state}
-                orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
-                save_args = orbax_utils.save_args_from_target(ckpt)
-                orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"tokenizer_{ts}_{step}"),
-                    ckpt,
-                    save_args=save_args,
-                )
-        if step >= args.num_steps:
-            break
+    # --- Initialize model ---
+    tokenizer = TokenizerVQVAE(
+        in_dim=args.image_channels,
+        model_dim=args.model_dim,
+        latent_dim=args.latent_dim,
+        num_latents=args.num_latents,
+        patch_size=args.patch_size,
+        num_blocks=args.num_blocks,
+        num_heads=args.num_heads,
+        dropout=args.dropout,
+        codebook_dropout=args.codebook_dropout,
+    )
+    rng, _rng = jax.random.split(rng)
+    image_shape = (args.image_resolution, args.image_resolution, args.image_channels)
+    inputs = dict(
+        videos=jnp.zeros(
+            (args.batch_size, args.seq_len, *image_shape), dtype=jnp.float32
+        ),
+    )
+    init_params = tokenizer.init(_rng, inputs)
+
+    # --- Load checkpoint ---
+    step = 0
+    if args.checkpoint:
+        init_params["params"].update(
+            PyTreeCheckpointer().restore(args.checkpoint)["model"]["params"]["params"]
+        )
+        # Assume checkpoint is of the form tokenizer_<timestamp>_<step>
+        step += int(args.checkpoint.split("_")[-1])
+
+    # --- Initialize optimizer ---
+    lr_schedule = optax.warmup_cosine_decay_schedule(
+        args.min_lr, args.max_lr, args.warmup_steps, args.num_steps
+    )
+    tx = optax.adamw(learning_rate=lr_schedule, b1=0.9, b2=0.9, weight_decay=1e-4)
+    train_state = TrainState.create(apply_fn=tokenizer.apply, params=init_params, tx=tx)
+
+    # --- TRAIN LOOP ---
+    dataloader = get_dataloader(args.data_dir, args.seq_len, args.batch_size)
+    while step < args.num_steps:
+        for videos in dataloader:
+            # --- Train step ---
+            rng, _rng = jax.random.split(rng)
+            inputs = dict(videos=videos, rng=_rng)
+            train_state, loss, recon, metrics = train_step(train_state, inputs)
+            print(f"Step {step}, loss: {loss}")
+            step += 1
+
+            # --- Logging ---
+            if args.log:
+                if step % args.log_interval == 0:
+                    wandb.log({"loss": loss, "step": step, **metrics})
+                if step % args.log_image_interval == 0:
+                    gt_seq = inputs["videos"][0]
+                    recon_seq = recon[0].clip(0, 1)
+                    comparison_seq = jnp.concatenate((gt_seq, recon_seq), axis=1)
+                    comparison_seq = einops.rearrange(
+                        comparison_seq * 255, "t h w c -> h (t w) c"
+                    )
+                    log_images = dict(
+                        image=wandb.Image(np.asarray(gt_seq[0])),
+                        recon=wandb.Image(np.asarray(recon_seq[0])),
+                        true_vs_recon=wandb.Image(
+                            np.asarray(comparison_seq.astype(np.uint8))
+                        ),
+                    )
+                    wandb.log(log_images)
+                if step % args.log_checkpoint_interval == 0:
+                    ckpt = {"model": train_state}
+                    orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
+                    save_args = orbax_utils.save_args_from_target(ckpt)
+                    orbax_checkpointer.save(
+                        os.path.join(
+                            os.getcwd(), args.ckpt_dir, f"tokenizer_{ts}_{step}"
+                        ),
+                        ckpt,
+                        save_args=save_args,
+                    )
+            if step >= args.num_steps:
+                break

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -1,35 +1,36 @@
+from pathlib import Path
+
+import jax.numpy as jnp
 import numpy as np
-import torch
 from torch.utils.data import Dataset, DataLoader
 
 
-def get_dataloader(file_path, seq_len, batch_size):
-    dataset = VideoDataset(file_path, seq_len)
-    # Convert batch of torch Tensors to numpy arrays for Flax
-    _collate_fn = lambda batch: [x.numpy() for x in batch]
+class VideoDataset(Dataset):
+    def __init__(self, data_dir, seq_len):
+        self.data_dir = Path(data_dir)
+        self.seq_len = seq_len
+        self.metadata = np.load(self.data_dir / "metadata.npy", allow_pickle=True)
+
+    def __len__(self):
+        return len(self.metadata)
+
+    def __getitem__(self, idx):
+        episode = np.load(self.metadata[idx]["path"])
+        start_idx = np.random.randint(0, len(episode) - self.seq_len + 1)
+        seq = episode[start_idx : start_idx + self.seq_len]
+        return seq.astype(np.float32) / 255.0
+
+
+def collate_fn(batch):
+    """Convert batch of numpy arrays to JAX array"""
+    return jnp.array(np.stack(batch))
+
+
+def get_dataloader(data_dir, seq_len, batch_size):
+    dataset = VideoDataset(data_dir, seq_len)
     return DataLoader(
         dataset,
         batch_size=batch_size,
         shuffle=True,
-        collate_fn=_collate_fn,
+        collate_fn=collate_fn,
     )
-
-
-class VideoDataset(Dataset):
-    def __init__(self, file_path, seq_len):
-        self.seq_len = seq_len
-        self.data_shape = np.load(file_path, mmap_mode="r").shape
-        self.data_file = file_path
-
-    def __len__(self):
-        return self.data_shape[0]
-
-    def __getitem__(self, index):
-        video = np.load(self.data_file, mmap_mode="r")[index]
-        total_frames = video.shape[0]
-        # Generate a random start index for the sequence
-        seq_start = np.random.randint(0, total_frames - self.seq_len + 1)
-        # Extract the sequence from the video
-        sequence = video[seq_start : seq_start + self.seq_len]
-        # Convert Numpy array to Torch tensor
-        return torch.from_numpy(sequence).clone()


### PR DESCRIPTION
* Save CoinRun trajectories to separate files.
* Load sub-trajectories in dataloader, avoiding episode resets.
* Refactor train and sample scripts.